### PR TITLE
Updating main

### DIFF
--- a/documentation/HowTo.md
+++ b/documentation/HowTo.md
@@ -112,30 +112,9 @@ NOTE: After update to XSLT 2.0 with GeoDCAT-AP 3.0.0, the examples may be outdat
 ````
 
 ### Python
-
-````python
-import lxml.etree as ET
-from urllib2 import urlopen
-
-# The URL of the XML document to be transformed. Here it corresponds to a "GetRecords" output of a fictitious CSW, with the "maxRecords" parameter set to 10.
-xmlURL = "http://some.site/csw?request=GetRecords&service=CSW&version=2.0.2&namespace=xmlns%28csw=http://www.opengis.net/cat/csw%29&resultType=results&outputSchema=http://www.isotc211.org/2005/gmd&outputFormat=application/xml&typeNames=csw:Record&elementSetName=full&constraintLanguage=CQL_TEXT&constraint_language_version=1.1.0&maxRecords=10"
-
-# The URL pointing to the latest version of the XSLT.
-xslURL = "https://raw.githubusercontent.com/SEMICeu/iso-19139-to-dcat-ap/master/iso-19139-to-dcat-ap.xsl"
-  
-xml = ET.parse(urlopen(xmlURL))
-xsl = ET.parse(urlopen(xslURL))
-
-transform = ET.XSLT(xsl)
-
-print(ET.tostring(transform(xml), pretty_print=True))
-````
-
-### Python: command line tool
-
-A Python script that can be used as a command line tool has been contributed by [@arbakker](https://github.com/arbakker):
-
-https://gist.github.com/arbakker/42f73421654b4d5f29211ead2ae0ab25/
+Examples: 
+* [Python](./examples/py/iso-19139-to-dcat-ap.py): A Python script that demonstrates how to use the `iso-19139-to-dcat-ap.xsl` XSLT transformation to convert ISO 19139 metadata records to DCAT-AP format.
+* [Python: command line tool](https://gist.github.com/arbakker/42f73421654b4d5f29211ead2ae0ab25/) [**`obsolete`**]: A Python script that can be used as a command line tool has been contributed by [@arbakker](https://github.com/arbakker):
 
 ### Java
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -6,4 +6,5 @@ More precisely:
 * [`HTTP-URIs.md`](./HTTP-URIs.md): Provides the list of transformation rules currently implemented for identifying URIs embedded in ISO 19139 metadata records.
 * [`Mappings.md`](./Mappings.md): Provides a summary of the mappings from ISO 19139 to (Geo)DCAT-AP.
 * [`README.md`](./README.md): This document.
-
+* [`examples`](./examples/): Contains example scripts and configurations.
+    * [Python](./examples/py/iso-19139-to-dcat-ap.py): A Python script that demonstrates how to use the `iso-19139-to-dcat-ap.xsl` XSLT transformation to convert ISO 19139 metadata records to DCAT-AP format.

--- a/documentation/examples/py/README.md
+++ b/documentation/examples/py/README.md
@@ -2,9 +2,9 @@
 
 ## Prerequisites
 
-Make sure you have Python 3.6 or higher installed on your system.
+Make sure you have [Python 3.6 ](https://www.python.org/downloads/)or higher installed on your system.
 
-## Creating a virtual environment
+### Creating a virtual environment
 
 To create a virtual environment, follow these steps:
 
@@ -38,9 +38,50 @@ To create a virtual environment, follow these steps:
         source env/bin/activate
         ```
 
-## Installing the prerequisites
+### Installing the prerequisites
 
 With the virtual environment activated, install the necessary prerequisites by running the following command:
 
+- On Windows, MacOS and Linux:
+
+    ```sh
+    pip install -r requirements.txt
+    ```
+
+## Configuration
+
+### Generating the `config.yaml`
+
+To configure the script, you need to create a `config.yaml` file based on the provided `config.yaml.example`. You can do this by copying the example file:
+
+- On Windows:
+
+    ```sh
+    copy config.yaml.example config.yaml
+    ```
+
+- On MacOS and Linux:
+
+    ```sh
+    cp config.yaml.example config.yaml
+    ```
+
+### Options in `config.yaml`
+
+- `xml_url`: The URL to the CSW endpoint. Example:
+  ```yaml
+  xml_url: http://some.site/csw?request=GetRecords&service=CSW&version=2.0.2&namespace=xmlns%28csw=http://www.opengis.net/cat/csw%29&resultType=results&outputSchema=http://www.isotc211.org/2005/gmd&outputFormat=application/xml&typeNames=csw:Record&elementSetName=full&constraintLanguage=CQL_TEXT&constraint_language_version=1.1.0&maxRecords=10
+  ```
+
+- `xsl_url`: The URL to the XSLT transformation or the local XSLT file path. Example:
+  ```yaml
+  xsl_url: https://raw.githubusercontent.com/mjanez/iso-19139-to-dcat-ap/refs/heads/develop/iso-19139-to-dcat-ap.xsl
+  ```
+
+### Running the script
+
+Once you have configured the `config.yaml` file, you can run the script as follows:
+
 ```sh
-pip install -r documentation/examples/py/requirements.txt
+python iso-19139-to-dcat-ap.py
+```

--- a/iso-19139-to-dcat-ap.xsl
+++ b/iso-19139-to-dcat-ap.xsl
@@ -1031,12 +1031,6 @@
         </xsl:apply-templates>
 -->
       </xsl:if>
-<!-- Metadata file identifier (tentative): only for the extended profile -->
-      <xsl:if test="$profile = $extended">
-        <xsl:for-each select="gmd:fileIdentifier/gco:CharacterString">
-          <dct:identifier rdf:datatype="{$xsd}string"><xsl:value-of select="."/></dct:identifier>
-        </xsl:for-each>
-      </xsl:if>
 <!-- Metadata standard (tentative): only for the extended profile -->
 <!-- Mapping moved to core profile for compliance with DCAT-AP 2 -->
 <!--
@@ -1183,6 +1177,12 @@
       <xsl:for-each select="gmd:identificationInfo/*/gmd:resourceMaintenance">
         <xsl:apply-templates select="gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode"/>
       </xsl:for-each>
+<!-- Metadata file identifier (tentative): only for the extended profile -->
+      <xsl:if test="$profile = $extended">
+        <xsl:for-each select="gmd:fileIdentifier/gco:CharacterString">
+          <dct:identifier rdf:datatype="{$xsd}string"><xsl:value-of select="."/></dct:identifier>
+        </xsl:for-each>
+      </xsl:if>
 <!-- Topic category -->
       <xsl:if test="$profile = $extended">
         <xsl:apply-templates select="gmd:identificationInfo/*/gmd:topicCategory">


### PR DESCRIPTION
This pull request includes updates to documentation and example scripts, as well as a minor change to the XSLT transformation file. The most important changes include reorganizing and updating Python examples, enhancing the documentation for creating virtual environments and configuring scripts, and modifying the XSLT transformation to ensure compliance with the extended profile.

Documentation and examples improvements:

* [`documentation/HowTo.md`](diffhunk://#diff-7debdfcf49b59ef89798ee3b13cecf6cc62bde28633505fd2ef1697e9b08677aL115-R117): Removed outdated inline Python example and replaced it with a link to an external Python script. Added a note about an obsolete command line tool.
* [`documentation/README.md`](diffhunk://#diff-ca8679f97c209358baaa7800674b0009d01a8ffe5eed884fc1db0cc7aff8d0c8L9-R10): Added a reference to the `examples` directory containing example scripts and configurations.
* [`documentation/examples/py/README.md`](diffhunk://#diff-4ba4844cfa6a1c50954c56dac148ec4752fc4ad03f1f24abdc67eada9fbabc65L5-R7): Enhanced documentation by adding detailed steps for creating a virtual environment, installing prerequisites, configuring the script using `config.yaml`, and running the script. [[1]](diffhunk://#diff-4ba4844cfa6a1c50954c56dac148ec4752fc4ad03f1f24abdc67eada9fbabc65L5-R7) [[2]](diffhunk://#diff-4ba4844cfa6a1c50954c56dac148ec4752fc4ad03f1f24abdc67eada9fbabc65L41-R87)

XSLT transformation update:

* [`iso-19139-to-dcat-ap.xsl`](diffhunk://#diff-a61731d87fff39b1a92569985b33f43359ef11b47f3a8ae128c3ab637cbb1804L1034-L1039): Moved the metadata file identifier mapping back to the extended profile section to ensure compliance with the extended profile requirements. [[1]](diffhunk://#diff-a61731d87fff39b1a92569985b33f43359ef11b47f3a8ae128c3ab637cbb1804L1034-L1039) [[2]](diffhunk://#diff-a61731d87fff39b1a92569985b33f43359ef11b47f3a8ae128c3ab637cbb1804R1180-R1185)